### PR TITLE
Chapter 2: Permissions Basics

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -1,4 +1,5 @@
-personal_ws-1.1 en 99 utf-8
+personal_ws-1.1 en 101 utf-8
+Addressability
 Collatz
 Datatypes
 Errorf
@@ -28,6 +29,7 @@ Viper
 Wireguard
 addToSlice
 addToSliceClient
+addressability
 arity
 bool
 boolean

--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 0 utf-8
+personal_ws-1.1 en 99 utf-8
 Collatz
 Datatypes
 Errorf

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -11,4 +11,7 @@
   - [requires, ensures, and preserves](./requires-ensures.md)
 - [Ghost code](./ghost.md)
 
+# Reasoning about Memory Accesses with Permissions
+- [Permission and swapping pointers](./basic-permissions.md)
+
 # Advanced topics

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,5 +14,6 @@
 # Reasoning about Memory Accesses with Permissions
 - [Permission to write](./permission-write.md)
 - [Self-Framing Assertions](./self-framing.md)
+- [Addressability and Sharing](./addressable.md)
 
 # Advanced topics

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -13,5 +13,6 @@
 
 # Reasoning about Memory Accesses with Permissions
 - [Permission to write](./permission-write.md)
+- [Self-Framing Assertions](./self-framing.md)
 
 # Advanced topics

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,6 +12,6 @@
 - [Ghost code](./ghost.md)
 
 # Reasoning about Memory Accesses with Permissions
-- [Permission and swapping pointers](./basic-permissions.md)
+- [Permission to write](./permission-write.md)
 
 # Advanced topics

--- a/src/addressable.md
+++ b/src/addressable.md
@@ -1,0 +1,58 @@
+# Addressability and Sharing
+
+If we try to take the address of a variable, we get an error from Gobra:
+``` go
+~func main() {
+	a := 1
+    x := &a
+~}
+```
+``` text
+property error: got a that is not effective addressable
+        x := &a
+      ^
+```
+In Go there is the notation of [addressability](https://go.dev/ref/spec#Address_operators) that defines when we can take the address `&a`.
+Gobra requires us to be explicit and mark the variable `a` as *shared*.
+This is done by appending the ampersand symbol to a variable name (`a@`) or equivalently in a comment with `a /*@@@*/`. 
+This should ensure that the programmer is aware, in which cases, Gobra employs the *permission machinery*.
+For example, we only need permissions for a shared array.
+While for an *exclusive* array we do not have to worry about data races and reasoning about them is much easier.
+
+Sometimes, an address is taken implicitly, as in the following example where the method `Scale` expects a receiver of type `*cell`:
+``` go
+type cell struct {
+	value int
+}
+//@ requires acc(&c.value, 1/2)
+func (c *cell) Scale(factor int) int {
+	return c.value * factor
+}
+func client2() {
+    // fix: mark c shared
+    // c /*@@@*/ := cell{5}
+	c := cell{5}
+	v := c.Scale(5)
+}
+```
+``` text
+ERROR Scale requires a shared receiver ('share' or '@' annotations might be missing).
+```
+
+As an exception, taking the address of a composite literal is allowed:
+``` go
+func client1() {
+	c := &cell{5}
+	v := c.Scale(5)
+}
+```
+
+## share
+Parameters of a function or method can be shared with the `share` statement at the beginning of the body.
+``` go
+func client3(c1, c2 cell) {
+	//@ share c1, c2
+	v := c1.Scale(5) + c2.Scale(10)
+}
+```
+

--- a/src/addressable.md
+++ b/src/addressable.md
@@ -17,21 +17,24 @@ Gobra requires us to be explicit and mark the variable `a` as *shared*.
 This is done by appending the ampersand symbol to a variable name (`a@`) or equivalently in a comment with `a /*@@@*/`. 
 This should ensure that the programmer is aware, in which cases, Gobra employs the *permission machinery*.
 For example, we only need permissions for a shared array.
-While for an *exclusive* array we do not have to worry about data races and reasoning about them is much easier.
+While for an *exclusive* array, we do not have to worry about data races and reasoning about them is much easier.
 
-Sometimes, an address is taken implicitly, as in the following example where the method `Scale` expects a receiver of type `*cell`:
+For structured variables of slice, shared arrays, or shared struct types, their elements or fields can be addressed individually.
+Access can be specified for example to the first element of a shared array with `acc(&a[0])` or to the field `x` of a shared struct `c` with `acc(&c.x)`.
+Sometimes, an address is taken implicitly, as in the following example where the method `Scale` expects a receiver of type `*Coord`:
 ``` go
-type cell struct {
-	value int
+type Coord struct {
+	x, y int
 }
-//@ requires acc(&c.value, 1/2)
-func (c *cell) Scale(factor int) int {
-	return c.value * factor
+
+// @ requires acc(&c.x) && acc(&c.y)
+func (c *Coord) Scale(factor int) Coord {
+	return Coord{x: c.x * factor, y: c.y * factor}
 }
-func client2() {
-    // fix: mark c shared
-    // c /*@@@*/ := cell{5}
-	c := cell{5}
+func client1() {
+	c := Coord{1, 2}
+	// fix: mark c shared
+	// c /*@@@*/ := Coord{1, 2}
 	v := c.Scale(5)
 }
 ```
@@ -41,8 +44,8 @@ ERROR Scale requires a shared receiver ('share' or '@' annotations might be miss
 
 As an exception, taking the address of a composite literal is allowed:
 ``` go
-func client1() {
-	c := &cell{5}
+func client2() {
+	c := &Coord{1, 2}
 	v := c.Scale(5)
 }
 ```
@@ -50,9 +53,10 @@ func client1() {
 ## share
 Parameters of a function or method can be shared with the `share` statement at the beginning of the body.
 ``` go
-func client3(c1, c2 cell) {
+func client3(c1, c2 Coord) {
 	//@ share c1, c2
-	v := c1.Scale(5) + c2.Scale(10)
+	v1 := c1.Scale(5)
+	v2 := c2.Scale(10)
 }
 ```
 

--- a/src/basic-permissions.md
+++ b/src/basic-permissions.md
@@ -1,0 +1,202 @@
+# Permission and swapping pointers
+
+Permissions allow us to reason about mutable data.
+Reading and writing to a location is permitted based on the permission amount held.
+Permissions can be transferred between functions/methods, loop iterations, and are gained on allocation.
+
+This is crucial for concurrency, as a short teaser, Gobra can reject the following program with a data race:
+``` go
+func inc(p *int) {
+	*p = *p + 1
+}
+
+func driver(p *int) {
+	go inc(p)
+	go inc(p)
+}
+```
+
+Permissions are held to *resources*.
+The following chapter will also introduce access to predicates but for now, we are concerned only with pointers.
+
+
+For a pointer to an integer `x *int`,
+the accessibility predicate `acc(x)` denotes write (and read) access to `x`.
+
+Having access `acc(x)` to a pointer `x` implies `x != nil` and that reading (e.g. `tmp := *x`) and writing (e.g. `*x = 1`) does not panic.
+
+Let us illustrate this with a function that swaps the values of two integer pointers:
+``` go
+func swap(x *int, y *int) {
+	tmp := *x
+	*x = *y
+	*y = tmp
+}
+```
+Go provides memory safety and does not try to access invalid memory.
+Similar to out-of-bounds array indices, a runtime error occurs when we call `swap(nil, x)`:
+``` text
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x466c23]
+
+goroutine 1 [running]:
+main.swap(...)
+        /gobra/swap.go:8
+main.main()
+        /gobra/swap.go:14 +0x3
+exit status 2
+```
+Gobra can detect this statically.
+Without access yet, we get the error:
+``` text
+Assignment might fail. 
+Permission to *x might not suffice.
+```
+The permissions a function requires must be specified in the precondition.
+Since `swap` modifies both `x` and `y` we write:
+``` go
+//@ requires acc(x) && acc(y)
+func swap(x *int, y *int) {
+~	tmp := *x
+~	*x = *y
+~	*y = tmp
+}
+```
+
+If we now try to swap,
+``` go
+func client() {
+	a := 1
+	b := 2
+    x := &a
+    y := &b
+	swap(x, y)
+}
+```
+we first get the error:
+``` text
+property error: got a that is not effective addressable
+        x := &a
+      ^
+```
+Gobra requires us to be explicit and mark a variable `a` that is referenced with `a /*@@@*/`.
+This should ensure that the programmer is aware, in which cases, Gobra employs the *permission machinery*.
+Otherwise, if the local variables `a` and `b` are never referenced, reasoning about them is much easier.
+Note that the outer `@`s belong to the annotation, so the equivalent in Gobra is just `a@`.
+``` go
+~func client() {
+	a /*@@@*/ := 1
+	b /*@@@*/ := 2
+    x := &a
+    y := &b
+	swap(x, y)
+	//@ assert *x == 2
+	//@ assert *y == 1
+}
+```
+
+Permissions are transferred to a function when the function is called and transferred back when the function returns.
+In our example, permissions `acc(x)` and `acc(y)` are obtained in `client` when initializing `x` and `y`,
+then transferred to `swap(x, y)`.
+Since `swap`'s postcondition does not mention any permissions, `acc(x)` and `acc(y)` are lost and not transferred back to the caller.
+The assertions require access as well since they read `x` and `y`:
+``` text
+Assert might fail. 
+Permission to *x might not suffice.
+```
+
+Let us fix this by adding postconditions.
+With `old(*y)` we can use the value of `*y` from the old state before the function.
+``` go
+//@ requires acc(x) && acc(y)
+//@ ensures acc(x) && acc(y)
+//@ ensures *x == old(*y) && *y == old(*x)
+func swap(x *int, y *int) {
+	~tmp := *x
+	~*x = *y
+	~*y = tmp
+}
+```
+
+## Aliasing
+Clients may want to call `swap` with the same argument `swap(x, x)`.
+So far, our specification forbids this and we get the error:
+``` go
+Precondition of call swap(x, x) might not hold. 
+Permission to y might not suffice.
+```
+Having `acc(x) && acc(y)` implies `x != y` since we are not allowed to have write access to the same location.
+
+One possibility is to perform a case distinction on `x == y`.
+While this works, the resulting specs are verbose, and we better refactor them to a reduced form.
+``` go
+//@ requires x == y ==> acc(x)
+//@ requires x != y ==> acc(x) && acc(y)
+//@ ensures x == y ==> acc(x)
+//@ ensures x != y ==> acc(x) && acc(y)
+//@ ensures x != y ==> *x == old(*y) && *y == old(*x)
+//@ ensures x == y ==> *x == old(*x)
+func swap(x *int, y *int) {
+	tmp := *x
+	*x = *y
+	*y = tmp
+}
+```
+
+1. It is a common pattern that a function requires and ensures the same permissions. Here we have
+    ``` go
+    //@ requires x == y ==> acc(x)
+    //@ ensures x == y ==> acc(x)
+    ```
+    We can replace this with a single line using `preserves`, which is syntactical sugar for the above.
+    ``` go
+    //@ preserves x == y ==> acc(x)
+    ```
+2. `acc(x)` is needed in any case, hence it can be factored out
+    ``` go
+    //@ preserves x == y ==> acc(x)
+    //@ preserves x != y ==> acc(x) && acc(y)
+    ```
+    becomes
+    ``` go
+    //@ preserves acc(x)
+    //@ preserves x != y ==> acc(y)
+    ```
+3. Simplify the postconditions
+    ``` go
+    //@ ensures x != y ==> *x == old(*y) && *y == old(*x)
+    //@ ensures x == y ==> *x == old(*x)
+    ```
+    with:
+    ``` go
+    //@ ensures *x == old(*y) && *y == old(*x)
+    ```
+    where the assertion is unchanged for the case `x != y` and we see it is equivalent for the case `x == y` by substituting `y` with `x`.
+
+
+We have simplified the specification significantly and the client can now use swap also in cases where `x` and `y` are aliases.
+This gives us the...
+
+## Final Version of `swap`
+``` go
+//@ preserves acc(x)
+//@ preserves x != y ==> acc(y)
+//@ ensures *x == old(*y) && *y == old(*x)
+func swap(x *int, y *int) {
+	tmp := *x
+	*x = *y
+	*y = tmp
+}
+func client() {
+	a /*@@@*/ := 1
+	b /*@@@*/ := 2
+	x := &a
+	y := &b
+	swap(x, x)
+	//@ assert *x == 1
+	swap(x, y)
+	//@ assert *x == 2
+	//@ assert *y == 1
+}
+```
+

--- a/src/permission-write.md
+++ b/src/permission-write.md
@@ -61,41 +61,20 @@ func swap(x *int, y *int) {
 ~	*x = *y
 ~	*y = tmp
 }
-```
 
-If we now try to swap,
-``` go
 func client() {
-	a := 1
-	b := 2
-    x := &a
-    y := &b
-	swap(x, y)
-}
-```
-we first get the error:
-``` text
-property error: got a that is not effective addressable
-        x := &a
-      ^
-```
-Gobra requires us to be explicit and mark a variable `a` that is referenced with `a /*@@@*/`.
-This should ensure that the programmer is aware, in which cases, Gobra employs the *permission machinery*.
-Otherwise, if the local variables `a` and `b` are never referenced, reasoning about them is much easier.
-Note that the outer `@`s belong to the annotation, so the equivalent in Gobra is just `a@`.
-``` go
-~func client() {
-	a /*@@@*/ := 1
-	b /*@@@*/ := 2
-    x := &a
-    y := &b
+	x := new(int)
+	y := new(int)
+    *x = 1
+    *y = 2
 	swap(x, y)
 	//@ assert *x == 2
 	//@ assert *y == 1
 }
 ```
 
-In our example, permissions `acc(x)` and `acc(y)` are obtained in `client` when initializing `x` and `y`,
+
+In our example, permissions `acc(x)` and `acc(y)` are obtained in `client` when they allocated with `new`,
 then transferred when calling `swap(x, y)`.
 We add the postcondition `acc(x) && acc(y)` to transfer the permissions back to the caller when the function returns.
 Otherwise the permissions are leaked (lost).
@@ -182,10 +161,10 @@ func swap(x *int, y *int) {
 	*y = tmp
 }
 func client() {
-	a /*@@@*/ := 1
-	b /*@@@*/ := 2
-	x := &a
-	y := &b
+	x := new(int)
+	y := new(int)
+    *x = 1
+    *y = 2
 	swap(x, x)
 	//@ assert *x == 1
 	swap(x, y)

--- a/src/permission-write.md
+++ b/src/permission-write.md
@@ -1,4 +1,4 @@
-# Permission and swapping pointers
+# Permission to write
 
 Permissions allow us to reason about mutable data.
 Reading and writing to a location is permitted based on the permission amount held.

--- a/src/permission-write.md
+++ b/src/permission-write.md
@@ -19,12 +19,9 @@ func driver(p *int) {
 Permissions are held to *resources*.
 The following chapter will also introduce access to predicates but for now, we are concerned only with pointers.
 
-
 For a pointer to an integer `x *int`,
 the accessibility predicate `acc(x)` denotes write (and read) access to `x`.
-
 Having access `acc(x)` to a pointer `x` implies `x != nil` and that reading (e.g. `tmp := *x`) and writing (e.g. `*x = 1`) does not panic.
-
 Let us illustrate this with a function that swaps the values of two integer pointers:
 ``` go
 func swap(x *int, y *int) {

--- a/src/permission-write.md
+++ b/src/permission-write.md
@@ -95,18 +95,12 @@ Note that the outer `@`s belong to the annotation, so the equivalent in Gobra is
 }
 ```
 
-Permissions are transferred to a function when the function is called and transferred back when the function returns.
 In our example, permissions `acc(x)` and `acc(y)` are obtained in `client` when initializing `x` and `y`,
-then transferred to `swap(x, y)`.
-Since `swap`'s postcondition does not mention any permissions, `acc(x)` and `acc(y)` are lost and not transferred back to the caller.
-The assertions require access as well since they read `x` and `y`:
-``` text
-Assert might fail. 
-Permission to *x might not suffice.
-```
+then transferred when calling `swap(x, y)`.
+We add the postcondition `acc(x) && acc(y)` to transfer the permissions back to the caller when the function returns.
+Otherwise the permissions are leaked (lost).
 
-Let us fix this by adding postconditions.
-With `old(*y)` we can use the value of `*y` from the old state before the function.
+With `old(*y)` we can use the value of `*y` from the state at the beginning of the function call before any modifications.
 ``` go
 //@ requires acc(x) && acc(y)
 //@ ensures acc(x) && acc(y)

--- a/src/permission-write.md
+++ b/src/permission-write.md
@@ -68,11 +68,14 @@ func client() {
     *x = 1
     *y = 2
 	swap(x, y)
-	//@ assert *x == 2
+	//@ assert *x == 2 // fail
 	//@ assert *y == 1
 }
 ```
-
+``` text
+ERROR Assert might fail. 
+Permission to *x might not suffice.
+```
 
 In our example, permissions `acc(x)` and `acc(y)` are obtained in `client` when they allocated with `new`,
 then transferred when calling `swap(x, y)`.

--- a/src/self-framing.md
+++ b/src/self-framing.md
@@ -2,7 +2,7 @@
 
 Assertions must be well-defined and require access to all locations being read.
 
-If we forget to transfer permissions back, the postcondition has no permission to read `*y` and `*x`.
+This applies also to contracts, in order to read `*x` and `*y` the postcondition must hold permission for `x` and `y`.
 ``` go
 //@ requires acc(x) && acc(y)
 //@ ensures *x == old(*y) && *y == old(*x)

--- a/src/self-framing.md
+++ b/src/self-framing.md
@@ -1,0 +1,47 @@
+# Self-Framing Assertions
+
+Assertions must be well-defined and require access to all locations being read.
+
+If we forget to transfer permissions back, the postcondition has no permission to read `*y` and `*x`.
+``` go
+//@ requires acc(x) && acc(y)
+//@ ensures *x == old(*y) && *y == old(*x)
+func swap(x *int, y *int) {
+	tmp := *x
+	*x = *y
+	*y = tmp
+}
+```
+``` text
+ERROR Method contract is not well-formed. 
+Permission to *x might not suffice.
+```
+
+We can make it self-framing:
+``` go
+//@ requires acc(x) && acc(y)
+//@ ensures acc(x) && acc(y)
+//@ ensures *x == old(*y) && *y == old(*x)
+func swap(x *int, y *int) {
+	tmp := *x
+	*x = *y
+	*y = tmp
+}
+```
+
+The order of pre/postconditions matters.
+When we exchange the postconditions we get the same error:
+``` go
+//@ requires acc(x) && acc(y)
+//@ ensures *x == old(*y) && *y == old(*x)
+//@ ensures acc(x) && acc(y)
+func swap(x *int, y *int) {
+	tmp := *x
+	*x = *y
+	*y = tmp
+}
+```
+``` text
+ERROR Method contract is not well-formed. 
+Permission to *x might not suffice.
+```


### PR DESCRIPTION
This section introduces the notion of permissions using `swap` as an example, similar to how I was taught permissions ;)
The following topics are covered:
- how permission is transferred
- access predicate (with write access for now)
- pointers
- memory safety, non nil pointers
- old
- exclusivity of full access
- how handle aliasing (in swap) 
- effective addressable