### PR TITLE
Mathtype reference

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -47,3 +47,6 @@
 # Advanced topics
 - [Quantifier Triggers](./triggers.md)
 - [Magic Wands](./magic-wands.md)
+
+---
+- [Mathematical types](./reference-mathematical-types.md)

--- a/src/mathematical-types.gobra
+++ b/src/mathematical-types.gobra
@@ -97,9 +97,11 @@ func dicts() {
 	assert len(m1) == 2
 	assert domain(m1) == set[string]{"one", "two"}
 	assert range(m1) == set[int]{1, 2}
-	m2 := m1["three" = 3, "zwei" = 2]
-	// update the map
-	m2["zwei"] = 1
-	assert m2["zwei"] == 1
+	// update dict
+	m2 := m1["three" = 3, "four" = 4]
+	// syntactic sugar for
+	m2 = m2["zwei" = 2]
+	m2["zwei"] = 2
+	assert m2["zwei"] == 2 && m2["three"] == 3 && m2["four"] == 4
 	// ANCHOR_END: dict
 }

--- a/src/mathematical-types.gobra
+++ b/src/mathematical-types.gobra
@@ -4,30 +4,45 @@ func sequences()  {
 	// ANCHOR: seq
 	// The empty sequence
 	empty := seq[int]{}
-	// len gives the length of the sequence
+	// Length of the sequence
 	assert len(empty) == 0
 	// Constructing from a literal
 	s := seq[int]{0, 1, 1, 2, 3}
-	// Constructing from a range
+	// Membership check
+	assert 1 in s && !(4 in s)
+	// Lookup
+	assert s[4] == 3
+	// Integer sequence shorthand
 	s1 := seq[0..5]
-	// Comparison with ==
+	// Comparison
 	assert seq[0..5] == seq[int]{0, 1, 2, 3, 4}
-
+	// Works also with other integer types such as byte
+	assert seq[0..2] == seq[byte]{byte(0), byte(1)}
+	assert seq[4..2] == seq[int]{}
 	s2 := seq[5..10]
 	s3 := seq[0..10]
 	// Concatentation of sequences with ++
 	assert s1 ++ s2 == s3
-
-	// Slicing sequences
+	// Subsequences
+	assert s3[0:5] == s1
+	// Omitting the first index
 	assert s3[:5] == s1
-
-	arr := [5]int{0, 1, 2, 3, 4}
+	// Omitting both indices
+	assert s3[:] == s3
+	// No well-defined requirements for sub-sequence indices
+	assert len(s3[5:1]) == 0
+	assert len(s3[-10:20]) == 10
 	// Conversion from an array
+	arr := [5]int{0, 1, 2, 3, 4}
 	s4 := seq(arr)
 	// Conversion from another sequence
-	s5 := seq(s4)
-	assert s4 == s5
-
+	assert s4 == seq(s4)
+	s5 := seq[int]{0, 0, 0}
+	// Create from sequence with update
+	s6 := s5[0 = 2]
+	// The original sequence is not modified (it is immutable)
+	assert s6[0] == 2 && s5[0] == 0
+	assert s5[0 = 2][1 = 4][2 = 8] == seq[int]{2, 4, 8}
 	// ANCHOR_END: seq
 }
 
@@ -41,27 +56,18 @@ func sets() {
 	assert s1 == s2
 	// Cardinality
 	assert len(s1) == len(s2)
-
 	// Conversion from a sequence
 	s3 := set(seq[int]{ 1, 2})
 	// Conversion from a set
 	s4 := set(s1)
-
 	// Membership
-	assert 1 in set[int]{1, 2}
-	assert !(0 in set[int]{1, 2})
-
-	// Subset
+	assert 1 in set[int]{1, 2} && !(0 in set[int]{1, 2})
+	// Set operations
 	assert set[int]{0, 2} subset set[int]{0, 1, 2}
-	// Union
 	assert set[int]{0, 2} union set[int]{1} == set[int]{0, 1, 2}
-	// Intersection
 	assert set[int]{0, 1} intersection set[int]{1, 2} == set[int]{1}
-	// Set difference
 	assert set[int]{0, 1} setminus set[int]{1, 2} == set[int]{0}
-
 	// ANCHOR_END: set
-
 	// TODO Conversion from an option
 }
 
@@ -69,29 +75,31 @@ func multisets() {
 	// ANCHOR: mset
 	m1 := mset[int]{1, 2, 3}
 	m2 := mset[int]{1, 2, 2, 3, 3, 3}
-	assert len(m1) == 3
-	assert len(m2) == 6
-	assert m1 != m2
-
+	assert len(m1) == 3 && len(m2) == 6
 	// Multiplicity
-	assert 2 # m2 == 2
-	assert 3 # m2 == 3
-	assert 4 # m2 == 0
-
-	// TODO conversion form sequence, multiset or option
-
-	// TODO some set operations
-
-	arr := [5]int{0, 1, 2, 3, 4}
-	// Conversion from an array
-	s4 := mset(arr)
-
+	assert 3 # m1 == 1 && 3 # m2 == 3
+	assert 4 # m1 == 0
+	// multiset operations
+	assert mset[int]{0, 1} union mset[int]{1} == mset[int]{0, 1, 1}
+	assert mset[int]{1, 1, 1} intersection mset[int]{1, 1, 2} == mset[int]{1, 1}
+	assert mset[int]{1, 1, 2} setminus mset[int]{1, 2, 2} == mset[int]{1}
+	assert mset[int]{1} subset mset[int]{1, 1}
+	assert !(mset[int]{1, 1} subset mset[int]{1})
 	// ANCHOR_END: mset
+	// TODO Conversion from sequence, multiset or option
 }
 
 
 func dicts() {
-	// TODO
 	// ANCHOR: dict
+	m1 := dict[string]int{ "one": 1, "two": 2}
+	assert m1["one"] == 1
+	assert len(m1) == 2
+	assert domain(m1) == set[string]{"one", "two"}
+	assert range(m1) == set[int]{1, 2}
+	m2 := m1["three" = 3, "zwei" = 2]
+	// update the map
+	m2["zwei"] = 1
+	assert m2["zwei"] == 1
 	// ANCHOR_END: dict
 }

--- a/src/reference-mathematical-types.md
+++ b/src/reference-mathematical-types.md
@@ -5,7 +5,7 @@ Examples illustrate the syntax and the operations.
 Note that mathematical types are ghost types and may only be used in ghost code.
 
 ## Sequences (`seq`)
-The type `seq[T]` represents an immutable and finite sequence with elements of type `T`.
+The type `seq[T]` represents a finite sequence with elements of type `T`.
 
 | expression `E` | type of `x` | type of `y` | result type of `E` | description                                                                             |
 |----------------|-------------|-------------|--------------------|--------------------------------------------------------------------------------------------|
@@ -41,8 +41,7 @@ The type `seq[T]` represents an immutable and finite sequence with elements of t
 <!-- [gobra-libs for sequences](https://github.com/viperproject/gobra-libs/blob/main/seqs/seqs.gobra) -->
 
 ## Sets (`set`)
-The type `set[T]` represents a [mathematical set](https://en.wikipedia.org/wiki/Set_(mathematics)) with elements of type `T`.
-Sets are immutable.
+The type `set[T]` represents [mathematical sets](https://en.wikipedia.org/wiki/Set_(mathematics)) with elements of type `T`.
 
 | expression `E`     | type of `x` | type of `y` | result type of `E` | description                            |
 |--------------------|-------------|-------------|--------------------|------------------------------------------------|
@@ -73,7 +72,7 @@ Sets are immutable.
 
 
 ## Multisets (`mset`)
-The type `mset[T]` represents immutable [multisets](https://en.wikipedia.org/wiki/Multiset) with elements of type `T`.
+The type `mset[T]` represents [multisets](https://en.wikipedia.org/wiki/Multiset) with elements of type `T`.
 Multisets are like sets but may contain the same element multiple times.
 The multiset operations respect the multiplicities of the elements.
 
@@ -100,7 +99,7 @@ The multiset operations respect the multiplicities of the elements.
 
 
 ## Dictionaries (`dict`)
-The type `dict[K]V` represents a **mutable** dictionary with keys of type `K` and values of type `V`.
+The type `dict[K]V` represents dictionaries with keys of type `K` and values of type `V`.
 
 | expression `E` | type of `x` | type of `y` | result type of `E` | description                                                     |
 |----------------|-------------|-------------|--------------------|-----------------------------------------------------------------|
@@ -109,7 +108,6 @@ The type `dict[K]V` represents a **mutable** dictionary with keys of type `K` an
 | `x == y`       | `dict[K]V`  | `dict[K]V`  | `bool`             | equality                                                        |
 | `x[y]`         | `dict[K]V`  | `K`         | `V`                | lookup the value associated with key `y` [^6]                                                    |
 | `m[x = y]`     | `K`         | `V`         | `dict[K]V`         | dict with additional mapping `(x, y)`, otherwise identical to the dict `m` |
-| `m[x] = y`     | `K`         | `V`         | `dict[K]V`         | mutate the dict `m` by updating/adding the mapping `(x, y)`               |
 | `len(x)`       | `dict[K]V`  |             | int                | number of keys                                                 |
 | `domain(x)`    | `dict[K]V`  |             | `set[K]`           | set of keys                                                     |
 | `range(x)`     | `dict[K]V`  |             | `set[V]`           | set of values                                                   |

--- a/src/reference-mathematical-types.md
+++ b/src/reference-mathematical-types.md
@@ -1,20 +1,69 @@
 # Mathematical types (`seq, set, mset, dict`)
+This section gives an overview of the mathematical types supported by Gobra and their operations.
+Examples illustrate the syntax and the operations.
 
-Mathematical types are ghost types and can therefore only be used in ghost code.
-
+Note that mathematical types are ghost types and may only be used in ghost code.
 
 ## Sequences (`seq`)
-The type `seq[T]` represents a [mathematical sequence](https://en.wikipedia.org/wiki/Sequence).
+The type `seq[T]` represents an immutable and finite sequence with elements of type `T`.
 
+| expression `E` | type of `x` | type of `y` | result type of `E` | description                                                                             |
+|----------------|-------------|-------------|--------------------|--------------------------------------------------------------------------------------------|
+| `x ++ y`       | `seq[T]`    | `seq[T]`    | `seq[T]`           | concatenation                                                                            |
+| `x == y`       | `seq[T]`    | `seq[T]`    | `bool`             | equality                                                                                   |
+| `x in y`       | `T`         | `seq[T]`    | `bool`             | `true` if and only if `x` is an element of `y`                                              |
+| `seq[T]{}`     |             |             | `seq[T]`           | empty sequence                                                                    |
+| `seq[T]{x, y}` | `T`         | `T`         | `seq[T]`           | literal[^1]                                                                     |
+| `seq[x..y]`    | `I`       | `I`       | `seq[I]` [^2]        | integer sequence \\( [i, i+1, \ldots, j-1] \\)                                             |
+| `len(x)`       | `seq[T]`    |             | `int`              | length                                                                                     |
+| `x[i]`         | `seq[T]`    |             | `T`                | lookup element at index `i` [^3]                                        |
+| `x[i = y]`     | `seq[T]`    | `T`         | `seq[T]`           | creates a sequence with element `y` at index `i`, otherwise identical to `x`. [^3] |
+| `x[i:j]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence [^4] |
+| `seq(x)`       | `seq[T]`    |             | `seq[T]`           | conversion from a sequence                                                                 |
+| `seq(x)`       | `seq[T]`    |             | `[N]T`             | conversion from an array of length `N`                                                     |
+
+[^1]: Sequence literals can be constructed with an arbitrary number of elements. The table only contains an example for two elements.
+[^2]: `I` is an arbitrary [integer type](https://go.dev/ref/spec#Numeric_types) (`byte`, `uint8`, `int`, ...)
+[^3]: The indices `i` and `j` are of _integer_ type. Requires `0 <= i && i < len(x)`.
+[^4]: Sub-sequence with elements between index `i` (inclusive) and index `j` (exclusive). If `i < 0` or `i` is omitted, the lower index is treated as 0. If `j > len(x)` or `j` is omitted, the upper index is treated as `len(x)`.
+
+<!-- | `x[i:j]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence \\( [x[i], x[i + 1], \ldots, x[j-1]] \\) | -->
+<!-- | `x[:j]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence \\( [x[0], x[1], \ldots, x[j-1]] \\) | -->
+<!-- | `x[i:]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence \\( [x[i], x[i + 1], \ldots, x[j-1]] \\) | -->
+<!-- | `x[:]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence \\( [x[0],x[1], \ldots, x[len(x)-1] \\) | -->
+
+
+### Example: `seq[int]`
 ``` go
 {{#include mathematical-types.gobra:seq}}
 ```
 
-
 <!-- [gobra-libs for sequences](https://github.com/viperproject/gobra-libs/blob/main/seqs/seqs.gobra) -->
 
 ## Sets (`set`)
-The type `set[T]` represents a [mathematical set](https://en.wikipedia.org/wiki/Set_(mathematics)).
+The type `set[T]` represents a [mathematical set](https://en.wikipedia.org/wiki/Set_(mathematics)) with elements of type `T`.
+Sets are immutable.
+
+| expression `E`     | type of `x` | type of `y` | result type of `E` | description                            |
+|--------------------|-------------|-------------|--------------------|------------------------------------------------|
+| `set[T]{}`         |             |             | `set[T]`           | \\( \varnothing \\)                            |
+| `set[T]{x, y}`     | `T`         | `T`         | `set[T]`           | \\( \\{x, y \\} \\), in general with an arbitrary number of elements.                            |
+| `x union y`        | `set[T]`    | `set[T]`    | `set[T]`           | \\( x \cup y \\)                               |
+| `x intersection y` | `set[T]`    | `set[T]`    | `set[T]`           | \\( x \cap y \\)                               |
+| `x setminus y`     | `set[T]`    | `set[T]`    | `set[T]`           | \\( x \setminus y\\)                           |
+| `x subset y`       | `set[T]`    | `set[T]`    | `bool`             | \\( x \subseteq y\\)                           |
+| `x == y`       | `set[T]`    | `set[T]`    | `bool`             | \\( x = y\\)                           |
+| `x in y`           | `T`         | `set[T]`    | `bool`             | \\( x \in y\\)                                 |
+| `len(x)`           | `set[T]`    |             | `int`              | \\( \|x\| \\)                                  |
+| `x # y`            | `T`         | `set[T]`    | int                | 1 if \\(x \in y\\) else 0                      |
+| `set(x)`           | `set[T]`    |             | `set[T]`           | conversion from a set                          |
+| `set(x)`           | `seq[T]`    |             | `set[T]`           | conversion from a sequence                     |
+<!-- | `set(x)`           | `option[T]`    |             | `set[T]`           | conversion from an option                          | -->
+
+ <!-- \\( \\cases{1  & \\text{if }x \\in y \\\\ 0 & \\text{else}} \\) -->
+
+
+### Example: `set[int]`
 
 ``` go
 {{#include mathematical-types.gobra:set}}
@@ -22,17 +71,68 @@ The type `set[T]` represents a [mathematical set](https://en.wikipedia.org/wiki/
 
 <!-- [gobra-libs for sets](https://github.com/viperproject/gobra-libs/blob/main/sets/sets.gobra) -->
 
-## Multisets (`mset`)
-The type `mset[T]` represents [multisets](https://en.wikipedia.org/wiki/Multiset).
-Multisets are like sets, but may contain the same element multiple times.
 
+## Multisets (`mset`)
+The type `mset[T]` represents immutable [multisets](https://en.wikipedia.org/wiki/Multiset) with elements of type `T`.
+Multisets are like sets but may contain the same element multiple times.
+The multiset operations respect the multiplicities of the elements.
+
+| expression `E`     | type of `x` | type of `y` | result type of `E` | description                            |
+|--------------------|-------------|-------------|--------------------|------------------------------------------------|
+| `mset[T]{}`         |             |             | `mset[T]`           |
+| `mset[T]{x, x}`     | `T`         | `T`         | `mset[T]`           | \\( \\{x, x \\} \\), in general with an arbitrary number of elements.                            |
+| `x union y`        | `mset[T]`    | `mset[T]`    | `mset[T]`           | 
+| `x intersection y` | `mset[T]`    | `mset[T]`    | `mset[T]`           |
+| `x setminus y`     | `mset[T]`    | `mset[T]`    | `mset[T]`           |
+| `x subset y`       | `mset[T]`    | `mset[T]`    | `bool`             |
+| `x == y`       | `mset[T]`    | `mset[T]`    | `bool`             | 
+| `x in y`           | `T`         | `mset[T]`    | `bool`             | 
+| `len(x)`           | `mset[T]`    |             | `int`              |
+| `x # y`            | `T`         | `mset[T]`   | int                | multiplicity of the element `x` in `y` |
+| `mset(x)`           | `mset[T]`    |             | `mset[T]`           | conversion from a multiset                          |
+| `mset(x)`           | `seq[T]`    |             | `mset[T]`           | conversion from a sequence                          |
+<!-- | `mset(x)`           | `option[T]`    |             | `mset[T]`           | conversion from an option                          | -->
+
+### Example: `mset[int]`
 ``` go
 {{#include mathematical-types.gobra:mset}}
 ```
 
 
-## TODO Dictionaries (`dict`)
+## Dictionaries (`dict`)
+The type `dict[K]V` represents a **mutable** dictionary with keys of type `K` and values of type `V`.
 
+| expression `E` | type of `x` | type of `y` | result type of `E` | description                                                     |
+|----------------|-------------|-------------|--------------------|-----------------------------------------------------------------|
+| `dict[K]V{}`   |             |             | `dict[K]V`         | empty dict                                                      |
+| `dict[K]V{x: y}`   |   `K`          |     `V`        | `dict[K]V`         | dict literal [^5] |
+| `x == y`       | `dict[K]V`  | `dict[K]V`  | `bool`             | equality                                                        |
+| `x[y]`         | `dict[K]V`  | `K`         | `V`                | lookup the value associated with key `y` [^6]                                                    |
+| `m[x = y]`     | `K`         | `V`         | `dict[K]V`         | dict with additional mapping `(x, y)`, otherwise identical to the dict `m` |
+| `m[x] = y`     | `K`         | `V`         | `dict[K]V`         | mutate the dict `m` by updating/adding the mapping `(x, y)`               |
+| `len(x)`       | `dict[K]V`  |             | int                | number of keys                                                 |
+| `domain(x)`    | `dict[K]V`  |             | `set[K]`           | set of keys                                                     |
+| `range(x)`     | `dict[K]V`  |             | `set[V]`           | set of values                                                   |
+
+[^5]: In general, more items may be given. For duplicate keys, an error is reported:
+    ``` go
+    m1 := dict[string]int{ "one": 1, "two": 2, "one": -1}
+    ```
+    ``` text
+    ERROR key appears twice in map literal
+        m1 := dict[string]int{ "one": 1, "two": 2, "one": -1}
+        ^
+    ```
+[^6]: Requires `y in domain(x)`. Otherwise, an error is reported:
+    ``` go
+    m1 := dict[string]int{ "one": 1, "two": 2}
+    assert m1["three"] == 3
+    ```
+    ``` text
+    ERROR Assert might fail. 
+    Key "three" might not be contained in m1.
+    ```
+### Example: `dict[string]int`
 ``` go
 {{#include mathematical-types.gobra:dict}}
 ```

--- a/src/reference-mathematical-types.md
+++ b/src/reference-mathematical-types.md
@@ -5,26 +5,26 @@ Examples illustrate the syntax and the operations.
 Note that mathematical types are ghost types and may only be used in ghost code.
 
 ## Sequences (`seq`)
-The type `seq[T]` represents a finite sequence with elements of type `T`.
+The type `seq[T]` represents finite sequences with elements of type `T`.
 
-| expression `E` | type of `x` | type of `y` | result type of `E` | description                                                                             |
-|----------------|-------------|-------------|--------------------|--------------------------------------------------------------------------------------------|
-| `x ++ y`       | `seq[T]`    | `seq[T]`    | `seq[T]`           | concatenation                                                                            |
-| `x == y`       | `seq[T]`    | `seq[T]`    | `bool`             | equality                                                                                   |
-| `x in y`       | `T`         | `seq[T]`    | `bool`             | `true` if and only if `x` is an element of `y`                                              |
-| `seq[T]{}`     |             |             | `seq[T]`           | empty sequence                                                                    |
-| `seq[T]{x, y}` | `T`         | `T`         | `seq[T]`           | literal[^1]                                                                     |
-| `seq[x..y]`    | `I`       | `I`       | `seq[I]` [^2]        | integer sequence \\( [i, i+1, \ldots, j-1] \\)                                             |
-| `len(x)`       | `seq[T]`    |             | `int`              | length                                                                                     |
-| `x[i]`         | `seq[T]`    |             | `T`                | lookup element at index `i` [^3]                                        |
-| `x[i = y]`     | `seq[T]`    | `T`         | `seq[T]`           | creates a sequence with element `y` at index `i`, otherwise identical to `x`. [^3] |
-| `x[i:j]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence [^4] |
-| `seq(x)`       | `seq[T]`    |             | `seq[T]`           | conversion from a sequence                                                                 |
-| `seq(x)`       | `seq[T]`    |             | `[N]T`             | conversion from an array of length `N`                                                     |
+| expression `E` | type of `x` | type of `y` | result type of `E` | description                                                                        |
+|----------------|-------------|-------------|--------------------|------------------------------------------------------------------------------------|
+| `x ++ y`       | `seq[T]`    | `seq[T]`    | `seq[T]`           | concatenation                                                                      |
+| `x[i]`         | `seq[T]`    |             | `T`                | lookup the element at index `i` [^1]                                               |
+| `x == y`       | `seq[T]`    | `seq[T]`    | `bool`             | equality                                                                           |
+| `x in y`       | `T`         | `seq[T]`    | `bool`             | `true` if and only if `x` is an element of `y`                                     |
+| `seq[T]{}`     |             |             | `seq[T]`           | empty sequence                                                                     |
+| `seq[T]{x, y}` | `T`         | `T`         | `seq[T]`           | literal[^2]                                                                        |
+| `seq[x..y]`    | `I`         | `I`         | `seq[I]` [^3]      | integer sequence \\( [x, x+1, \ldots, y-1] \\)                                     |
+| `len(x)`       | `seq[T]`    |             | `int`              | length                                                                             |
+| `x[i = y]`     | `seq[T]`    | `T`         | `seq[T]`           | creates a sequence with element `y` at index `i`, otherwise identical to `x`. [^1] |
+| `x[i:j]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence [^4]                                                                  |
+| `seq(x)`       | `seq[T]`    |             | `seq[T]`           | conversion from a sequence                                                         |
+| `seq(x)`       | `seq[T]`    |             | `[N]T`             | conversion from an array of length `N`                                             |
 
-[^1]: Sequence literals can be constructed with an arbitrary number of elements. The table only contains an example for two elements.
-[^2]: `I` is an arbitrary [integer type](https://go.dev/ref/spec#Numeric_types) (`byte`, `uint8`, `int`, ...)
-[^3]: The indices `i` and `j` are of _integer_ type. Requires `0 <= i && i < len(x)`.
+[^1]: The indices `i` and `j` are of _integer_ type. Requires `0 <= i && i < len(x)`.
+[^2]: Sequence literals can be constructed with an arbitrary number of elements. The table only contains an example for two elements.
+[^3]: `I` is an arbitrary [integer type](https://go.dev/ref/spec#Numeric_types) (`byte`, `uint8`, `int`, ...)
 [^4]: Sub-sequence with elements between index `i` (inclusive) and index `j` (exclusive). If `i < 0` or `i` is omitted, the lower index is treated as 0. If `j > len(x)` or `j` is omitted, the upper index is treated as `len(x)`.
 
 <!-- | `x[i:j]`       | `seq[T]`    |             | `seq[T]`           | sub-sequence \\( [x[i], x[i + 1], \ldots, x[j-1]] \\) | -->


### PR DESCRIPTION
Adds a reference page for the mathematical types
- `seq[T]`
- `mset[T]`
- `set[T]`
- `dict[K]V`

The operations are summarized in a table.
Small client examples are included