### PR TITLE
Highlight errors from gobra-playground

### DIFF
--- a/gobra-book.js
+++ b/gobra-book.js
@@ -9,8 +9,6 @@ const GO_PLAYGROUND = new URL("https://gobra.void.gschall.ch/run");
 // extracted and refactored elements
 // Added functionality to support Go and Gobra
 const DEFAULT_LANGUAGE = "text";
-const GOBRA_INLINE = /\/\*@.*@\*\//g;
-const GOBRA_COMMENT = /\/\/\s*?@/;
 
 function fetch_with_timeout(url, options, timeout = 20000) {
   return Promise.race([
@@ -174,7 +172,8 @@ const verifyButton = (id) =>
     "fa-check-circle-o",
     "Verify with Gobra",
     (ctxt) => {
-      const code = ctxt.editor.getSession().getValue();
+      const session = ctxt.editor.getSession();
+      const code = session.getValue();
       const container = ctxt.editor.container.parentNode;
       let result_block = container.querySelector(".result");
       if (!result_block) {
@@ -198,9 +197,18 @@ const verifyButton = (id) =>
             result_block.innerHTML += `<span> Verification failed, taking ${duration}</span>`;
             result_block.innerHTML += errors
               .map((err) => {
-                // let position = `(${err.Position.line}, ${err.Position.char})`
+                let position = `${err.Position.line},${err.Position.char}`;
                 // TODO highlight in editor
-                return `<p>ERROR: ${err.message}</p>`;
+                const line = err.Position.line - 1;
+                const char = err.Position.char - 1;
+                const lineLen = code.split("\n")[line].length + 1;
+                // also clear it again...
+                session.addMarker(
+                  new AceRange(line, char, line, lineLen),
+                  "errorHighlight",
+                  "singleLine",
+                );
+                return `<p>ERROR (${position}): ${err.message}</p>`;
               })
               .join("");
           }
@@ -226,6 +234,13 @@ function initBlock(code_block) {
   }
   let editor = ace.edit(code_block);
   let session = editor.getSession();
+  session.on("change", function () {
+    // clear error highlights
+    session.clearAnnotations();
+    Object.keys(session.getMarkers()).forEach((markerId) =>
+      session.removeMarker(markerId),
+    );
+  });
   const showLines = window.playground_line_numbers || !noEdit;
   // Configure the editor
   editor.setOptions({
@@ -246,13 +261,7 @@ function initBlock(code_block) {
   if (noEdit) {
     session.setValue(hiddenCode);
   }
-  // TODO extract error information
   // Bind Commands to keybindings
-  editor.commands.addCommand({
-    name: "highlightSpecs",
-    bindKey: { win: "Ctrl-L", mac: "Cmd-L" },
-    exec: specsToggler(),
-  });
   editor.commands.addCommand({
     name: "runGo",
     bindKey: {
@@ -322,64 +331,4 @@ function initializeCodeBlocks() {
 addEventListener("DOMContentLoaded", () => {
   initializeCodeBlocks();
 });
-// Showcases the use of Marker and Range,
-// in the following form this wont be a useful functionality
-// Toggle the display of Gobra annotations within Go files
-// Handle line comments starting with //@
-// and inline comments of the form /*@ ... @*/
-function specsToggler() {
-  var hidden = false;
-  var markers = [];
-  return (editor) => {
-    console.debug("Toggling specs display");
-    var session = editor.getSession();
-    hidden = !hidden;
-    markers.forEach((marker) => editor.getSession().removeMarker(marker));
-    markers = [];
-    if (!hidden) {
-      return;
-    }
-    var doc = session.getDocument();
-    var lines = doc.getAllLines();
-    lines.forEach((line, line_number) => {
-      let match = line.match(GOBRA_COMMENT);
-      if (match) {
-        console.debug("Found gobra line: ", line);
-        markers.push(
-          session.addMarker(
-            new AceRange(
-              line_number,
-              match.index,
-              line_number,
-              line.length + 1,
-            ),
-            "errorHighlight",
-            "fullLine",
-          ),
-        );
-      }
-      let matches = line.match(GOBRA_INLINE);
-      if (matches) {
-        matches.forEach((match) => {
-          let start = line.indexOf(match);
-          let end = start + match.length;
-          console.debug(
-            "Found gobra annotation: ",
-            match,
-            line_number,
-            start,
-            end,
-          );
-          markers.push(
-            session.addMarker(
-              new AceRange(line_number, start, line_number, end),
-              "errorHighlight",
-              "text",
-            ),
-          );
-        });
-      }
-    });
-  };
-}
 export {};

--- a/gobra-book.js
+++ b/gobra-book.js
@@ -197,18 +197,21 @@ const verifyButton = (id) =>
             result_block.innerHTML += `<span> Verification failed, taking ${duration}</span>`;
             result_block.innerHTML += errors
               .map((err) => {
-                let position = `${err.Position.line},${err.Position.char}`;
-                // TODO highlight in editor
                 const line = err.Position.line - 1;
                 const char = err.Position.char - 1;
-                const lineLen = code.split("\n")[line].length + 1;
-                // also clear it again...
-                session.addMarker(
-                  new AceRange(line, char, line, lineLen),
-                  "errorHighlight",
-                  "singleLine",
-                );
-                return `<p>ERROR (${position}): ${err.message}</p>`;
+                const codeLines = code.split("\n");
+                if (0 <= line && line < codeLines.length) {
+                  const lineLen = codeLines[line].length + 1;
+                  // also clear it again...
+                  session.addMarker(
+                    new AceRange(line, char, line, lineLen),
+                    "errorHighlight",
+                    "singleLine",
+                  );
+                  let position = `${err.Position.line},${err.Position.char}`;
+                  return `<p>ERROR (${position}): ${err.message}</p>`;
+                }
+                return `<p>ERROR: ${err.message}</p>`;
               })
               .join("");
           }

--- a/theme/css/general.css
+++ b/theme/css/general.css
@@ -68,7 +68,13 @@ h6 code {
 .errorHighlight {
     position: absolute;
     z-index: 20;
-    background-color: red;
+    text-decoration: none;
+    background-image: url("data:image/svg+xml,\
+    <svg xmlns='http://www.w3.org/2000/svg' width='6' height='3'>\
+      <path d='M 0 3 Q 1.5 0 3 3 T 6 3' stroke='red' fill='transparent' stroke-width='1'/>\
+    </svg>");
+    background-repeat: repeat-x;
+    background-position: bottom;
 }
 
 .ace_hide_line {


### PR DESCRIPTION
- Highlight errors received from the gobra-playground in the editor
- the annotations are cleared again if the code is edited
- some errors have no locations (e.g., LogicException)
- Gobra gives only the starting position of an error. Hence, we highlight from the start of the error to the end of the line

Example:
![image](https://github.com/user-attachments/assets/8b9015e1-df9e-4185-b887-c6f8089b50b4)

Nice to have (not implemented): show the error message when hovering the line.