### PR TITLE
fix: Markdown

### DIFF
--- a/src/03/predicates-fractional.md
+++ b/src/03/predicates-fractional.md
@@ -9,7 +9,7 @@ Equivalently, we can write `acc(l.Mem())` or `acc(l.Mem(), 1)` using the access 
 <!-- {{#include list.go:mem}} -->
 <!-- ``` -->
 
-We may specify a permission amount' p` for `fold`, `unfold`, and `unfolding`.
+We may specify a permission amount `p` for `fold`, `unfold`, and `unfolding`.
 In this case, any permission amount in the body of the predicate is multiplied by `p`.
 For example, the body of `l.Mem()` contains `acc(l)` and `l.next.Mem()`.
 After `unfold acc(l.Mem())`, only `acc(l, 1/2)` and `acc(l.next.Mem(), 1/2)` are held.


### PR DESCRIPTION
A `'` in place of a `` ` `` caused this paragraph to render incorrectly:

<img width="720" height="103" alt="image" src="https://github.com/user-attachments/assets/a270189e-3fc9-426b-b451-b4b21c665751" />