### PR TITLE
Fix 'in' into 'elem' in Chapter 2: map

### DIFF
--- a/src/01/termination.md
+++ b/src/01/termination.md
@@ -16,7 +16,7 @@ It is still partially correct with respect to its contract since the postconditi
 
 ``` go verifies
 // @ ensures false
-func infiniteZero() res {
+func infiniteZero() (res int) {
     for {}
     return 0
 }

--- a/src/02/maps.md
+++ b/src/02/maps.md
@@ -13,18 +13,18 @@ Holding write permissions, we can add entries.
 In specifications, we can check with `in` if a key is contained in the map.
 ``` go verifies
 watched["Blade Runner"] = true
-// @ assert "Blade Runner" in watched && len(watched) == 1
+// @ assert "Blade Runner" elem watched && len(watched) == 1
 ```
 
 The values can be retrieved with their keys.
 Note that key elements must be comparable.
 For example, one cannot use other maps, slices, and functions as keys.
 ``` go verifies
-elem, ok := watched["Blade Runner"]
-// @ assert ok && elem
+element, ok := watched["Blade Runner"]
+// @ assert ok && element
 // non-existing key
-elem, ok := watched["Dune"]
-// @ assert !ok && !elem
+element, ok := watched["Dune"]
+// @ assert !ok && !element
 ```
 
 ## `nil` map


### PR DESCRIPTION
The keyword `in` in Gobra will cause the following error in the v25.09:

```
No changes detected in the antlr4 files. Skipping parser generation.
[info] running (fork) viper.gobra.GobraRunner -i /Users/.../exercises/tutorial20.go
[info] Gobra 1.1-SNAPSHOT (67df1a36@(detached))
[info] (c) Copyright ETH Zurich 2012 - 2024
[info] Verifying package .. - exercises [10:21:55]
[info] Error at: </Users/.../exercises/tutorial20.go:17:23> Unexpected 'in' encountered. Did you mean to use 'elem' denoting ghost collection membership?
[info] 	assert "Blade Runner" in watched && len(watched) == 1
[info]                        ^^
[info] Gobra found 1 error.
[info]
[error] Nonzero exit code returned from runner: 1
[error] (Compile / run) Nonzero exit code returned from runner: 1
[error] Total time: 4 s, completed 13 Nov 2025, 10:21:56
```

The correct way is to use `elem`. But this will cause another issue with another line in the gobra-book which defines the variable as `elem`, which could be an issue with the parser of the Gobra version:

```
No changes detected in the antlr4 files. Skipping parser generation.
[info] running (fork) viper.gobra.GobraRunner -i /Users/.../exercises/tutorial20.go
[info] Gobra 1.1-SNAPSHOT (67df1a36@(detached))
[info] (c) Copyright ETH Zurich 2012 - 2024
[info] Verifying package .. - exercises [10:37:34]
[info] Error at: </Users/.../exercises/tutorial20.go:22:14> Unexpected reserved word elem.
[info] 	assert ok && elem
[info]               ^^^^
[info] Gobra found 1 error.
[info]
[error] Nonzero exit code returned from runner: 1
[error] (Compile / run) Nonzero exit code returned from runner: 1
[error] Total time: 4 s, completed 13 Nov 2025, 10:37:35
```

So I changed `elem` to `element` in the consequent lines.