### PR TITLE
"must not" -> "need not"

### DIFF
--- a/src/02/self-framing.md
+++ b/src/02/self-framing.md
@@ -66,7 +66,7 @@ is self-framing, while the following is not:
 // @ ensures *x == old(*y) && acc(x) && acc(y)
 ```
 
-As an exception, the assertion from an `assert` statement must not be self-framing.
+As an exception, the assertion from an `assert` statement need not be self-framing.
 For example, we can write `*x == 1` instead of `acc(x) && *x == 1`.
 However, Gobra reports an error if `acc(x)` is not held in the state.
 ``` go verifies

--- a/src/02/self-framing.md
+++ b/src/02/self-framing.md
@@ -66,7 +66,7 @@ is self-framing, while the following is not:
 // @ ensures *x == old(*y) && acc(x) && acc(y)
 ```
 
-As an exception, the assertion from an `assert` statement need not be self-framing.
+As an exception, the assertion in an `assert` statement need not be self-framing.
 For example, we can write `*x == 1` instead of `acc(x) && *x == 1`.
 However, Gobra reports an error if `acc(x)` is not held in the state.
 ``` go verifies


### PR DESCRIPTION
I think the language is wrong here as the example `acc(x) && *x == 1` is self-framing. That means, assertions in assert statements *may* be self-framing, but it is written that they must not be.