### PR TITLE
'in' -> 'elem'

### DIFF
--- a/mode-gobra.js
+++ b/mode-gobra.js
@@ -71,7 +71,7 @@ ace.define(
     var GobraHighlightRules = function () {
       var gobra_keywords =
         "invariant|requires|ensures|preserves|trusted|share|opaque|reveal|outline|pred|pure|exists|forall|assume|apply|inhale|exhale|assert|refute|ghost|implements|unfolding|let|fold|unfold|decreases|as|domain|axiom|adt|match|shared|exclusive|predicate|writePerm|noPerm|initEnsures|importRequires|proof|with|backend";
-      var gobra_operators = "==>|::|in|===|!==|@|--*|#|<!|!>"; // .. ?
+      var gobra_operators = "==>|::|in|elem|===|!==|@|--*|#|<!|!>"; // .. ?
       var gobra_types = "seq|set|mset|dict|option|gpointer";
       var gobra_functions = "acc|old|before|some|get|none|typeOf|isComparable";
 

--- a/mode-golang.js
+++ b/mode-golang.js
@@ -71,7 +71,7 @@ ace.define(
     var GolangHighlightRules = function () {
       var gobra_keywords =
         "invariant|requires|ensures|preserves|trusted|share|opaque|reveal|outline|pred|pure|exists|forall|assume|apply|inhale|exhale|assert|refute|ghost|implements|unfolding|let|fold|unfold|decreases|as|domain|axiom|adt|match|shared|exclusive|predicate|writePerm|noPerm|initEnsures|importRequires|proof|with|backend";
-      var gobra_operators = "==>|::|in|===|!==|@|--*|#|<!|!>"; // .. ?
+      var gobra_operators = "==>|::|in|elem|===|!==|@|--*|#|<!|!>"; // .. ?
       var gobra_types = "seq|set|mset|dict|option|gpointer";
       var gobra_functions = "acc|old|before|some|get|none|typeOf|isComparable";
 

--- a/src/02/maps.md
+++ b/src/02/maps.md
@@ -10,7 +10,7 @@ The accessibility predicate `acc(watched)` is for the entire map.
 Individual elements, as in slices, are not addressable.
 
 Holding write permissions, we can add entries.
-In specifications, we can check with `in` if a key is contained in the map.
+In specifications, we can check with `elem` if a key is contained in the map.
 ``` go verifies
 watched["Blade Runner"] = true
 // @ assert "Blade Runner" elem watched && len(watched) == 1

--- a/src/mathematical-types.gobra
+++ b/src/mathematical-types.gobra
@@ -9,7 +9,7 @@ func sequences()  {
 	// Constructing from a literal
 	s := seq[int]{0, 1, 1, 2, 3}
 	// Membership check
-	assert 1 in s && !(4 in s)
+	assert 1 elem s && !(4 elem s)
 	// Lookup
 	assert s[4] == 3
 	// Integer sequence shorthand
@@ -61,7 +61,7 @@ func sets() {
 	// Conversion from a set
 	s4 := set(s1)
 	// Membership
-	assert 1 in set[int]{1, 2} && !(0 in set[int]{1, 2})
+	assert 1 elem set[int]{1, 2} && !(0 elem set[int]{1, 2})
 	// Set operations
 	assert set[int]{0, 2} subset set[int]{0, 1, 2}
 	assert set[int]{0, 2} union set[int]{1} == set[int]{0, 1, 2}

--- a/src/reference-mathematical-types.md
+++ b/src/reference-mathematical-types.md
@@ -12,7 +12,7 @@ The type `seq[T]` represents finite sequences with elements of type `T`.
 | `x ++ y`       | `seq[T]`    | `seq[T]`    | `seq[T]`           | concatenation                                                                      |
 | `x[i]`         | `seq[T]`    |             | `T`                | lookup the element at index `i` [^1]                                               |
 | `x == y`       | `seq[T]`    | `seq[T]`    | `bool`             | equality                                                                           |
-| `x in y`       | `T`         | `seq[T]`    | `bool`             | `true` if and only if `x` is an element of `y`                                     |
+| `x elem y`     | `T`         | `seq[T]`    | `bool`             | `true` if and only if `x` is an element of `y`                                     |
 | `seq[T]{}`     |             |             | `seq[T]`           | empty sequence                                                                     |
 | `seq[T]{x, y}` | `T`         | `T`         | `seq[T]`           | literal[^2]                                                                        |
 | `seq[x..y]`    | `I`         | `I`         | `seq[I]` [^3]      | integer sequence \\( [x, x+1, \ldots, y-1] \\)                                     |
@@ -52,7 +52,7 @@ The type `set[T]` represents [mathematical sets](https://en.wikipedia.org/wiki/S
 | `x setminus y`     | `set[T]`    | `set[T]`    | `set[T]`           | \\( x \setminus y\\)                           |
 | `x subset y`       | `set[T]`    | `set[T]`    | `bool`             | \\( x \subseteq y\\)                           |
 | `x == y`       | `set[T]`    | `set[T]`    | `bool`             | \\( x = y\\)                           |
-| `x in y`           | `T`         | `set[T]`    | `bool`             | \\( x \in y\\)                                 |
+| `x elem y`         | `T`         | `set[T]`    | `bool`             | \\( x \in y\\)                                 |
 | `len(x)`           | `set[T]`    |             | `int`              | \\( \|x\| \\)                                  |
 | `x # y`            | `T`         | `set[T]`    | int                | 1 if \\(x \in y\\) else 0                      |
 | `set(x)`           | `set[T]`    |             | `set[T]`           | conversion from a set                          |
@@ -85,7 +85,7 @@ The multiset operations respect the multiplicities of the elements.
 | `x setminus y`     | `mset[T]`    | `mset[T]`    | `mset[T]`           |
 | `x subset y`       | `mset[T]`    | `mset[T]`    | `bool`             |
 | `x == y`       | `mset[T]`    | `mset[T]`    | `bool`             | 
-| `x in y`           | `T`         | `mset[T]`    | `bool`             | 
+| `x elem y`         | `T`         | `mset[T]`    | `bool`             |
 | `len(x)`           | `mset[T]`    |             | `int`              |
 | `x # y`            | `T`         | `mset[T]`   | int                | multiplicity of the element `x` in `y` |
 | `mset(x)`           | `mset[T]`    |             | `mset[T]`           | conversion from a multiset                          |
@@ -121,7 +121,7 @@ The type `dict[K]V` represents dictionaries with keys of type `K` and values of 
         m1 := dict[string]int{ "one": 1, "two": 2, "one": -1}
         ^
     ```
-[^6]: Requires `y in domain(x)`. Otherwise, an error is reported:
+[^6]: Requires `y elem domain(x)`. Otherwise, an error is reported:
     ``` go
     m1 := dict[string]int{ "one": 1, "two": 2}
     assert m1["three"] == 3


### PR DESCRIPTION
The book introduces `in` as keyword to do set/dict membership checks, but it's `elem`. This PR fixes that.

Please review my changes to the `.js` files. Not sure whether these are correct too, but it seemed right.